### PR TITLE
Fix RSVP subject and use absolute image paths

### DIFF
--- a/future-events.html
+++ b/future-events.html
@@ -25,7 +25,7 @@
           <strong>Fall Open Tournament</strong> – August 2025<br>
           Location: EHS Student Union<br>
           Time: 10:00 AM – 2:00 PM<br>
-          <a class="btn" href="mailto:contact@emerald-knights.org?subject=RSVP%20Summer%20Tournament">RSVP Now</a>
+          <a class="btn" href="mailto:contact@emerald-knights.org?subject=RSVP%20Fall%20Open%20Tournament">RSVP Now</a>
         </li>
         <!-- Add more events here if needed -->
       </ul>

--- a/past-events.html
+++ b/past-events.html
@@ -8,7 +8,7 @@
 </head>
 <body>
   <header>
-    <img src="images/emerald-knights-logo.png" alt="Emerald Knights Logo" class="logo">
+    <img src="/images/emerald-knights-logo.png" alt="Emerald Knights Logo" class="logo">
     <h1>Emerald Knights Chess Club</h1>
     <nav>
       <a href="index.html">About Us</a>
@@ -30,10 +30,10 @@
             <li>400-800 Section: Vikram Snyder</li>
           </ul>
           <div class="event-photos">
-            <img src="images/PXL_20250301_203352661.MP.jpg" alt="Tournament Photo 1">
-            <img src="images/PXL_20250301_203423033.jpg" alt="Tournament Photo 2">
-            <img src="images/PXL_20250301_203701347.MP.jpg" alt="Tournament Photo 3">
-            <img src="images/PXL_20250301_215649634.MP.jpg" alt="Tournament Photo 4">
+            <img src="/images/PXL_20250301_203352661.MP.jpg" alt="Tournament Photo 1">
+            <img src="/images/PXL_20250301_203423033.jpg" alt="Tournament Photo 2">
+            <img src="/images/PXL_20250301_203701347.MP.jpg" alt="Tournament Photo 3">
+            <img src="/images/PXL_20250301_215649634.MP.jpg" alt="Tournament Photo 4">
           </div>
         </li>
       </ul>


### PR DESCRIPTION
## Summary
- Correct event RSVP link to mention “Fall Open Tournament” instead of “Summer Tournament”
- Use absolute paths for logo and photos on past events page to ensure assets load

## Testing
- `npx htmlhint future-events.html past-events.html` *(fails: 403 Forbidden - GET https://registry.npmjs.org/htmlhint)*

------
https://chatgpt.com/codex/tasks/task_e_68aba8d78cec83318a65924fce71f83a