### PR TITLE
Replace Past/Future nav links with Events dropdown

### DIFF
--- a/chess-literacy.html
+++ b/chess-literacy.html
@@ -16,8 +16,13 @@
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
         <a href="index.html">About Us</a>
-        <a href="future-events.html">Future Events</a>
-        <a href="past-events.html">Past Events</a>
+        <div class="nav-dropdown">
+          <a href="future-events.html" class="dropdown-toggle">Events</a>
+          <div class="nav-dropdown-menu">
+            <a href="future-events.html">Future Events</a>
+            <a href="past-events.html">Past Events</a>
+          </div>
+        </div>
         <a href="chess-literacy.html" class="active">Chess Literacy</a>
       </nav>
     </div>

--- a/future-events.html
+++ b/future-events.html
@@ -16,8 +16,13 @@
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
         <a href="index.html">About Us</a>
-        <a href="future-events.html" class="active">Future Events</a>
-        <a href="past-events.html">Past Events</a>
+        <div class="nav-dropdown">
+          <a href="future-events.html" class="dropdown-toggle">Events</a>
+          <div class="nav-dropdown-menu">
+            <a href="future-events.html">Future Events</a>
+            <a href="past-events.html">Past Events</a>
+          </div>
+        </div>
         <a href="chess-literacy.html">Chess Literacy</a>
       </nav>
     </div>

--- a/index.html
+++ b/index.html
@@ -16,8 +16,13 @@
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
         <a href="index.html" class="active">About Us</a>
-        <a href="future-events.html">Future Events</a>
-        <a href="past-events.html">Past Events</a>
+        <div class="nav-dropdown">
+          <a href="future-events.html" class="dropdown-toggle">Events</a>
+          <div class="nav-dropdown-menu">
+            <a href="future-events.html">Future Events</a>
+            <a href="past-events.html">Past Events</a>
+          </div>
+        </div>
         <a href="chess-literacy.html">Chess Literacy</a>
       </nav>
     </div>

--- a/past-events.html
+++ b/past-events.html
@@ -16,8 +16,13 @@
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
         <a href="index.html">About Us</a>
-        <a href="future-events.html">Future Events</a>
-        <a href="past-events.html" class="active">Past Events</a>
+        <div class="nav-dropdown">
+          <a href="future-events.html" class="dropdown-toggle">Events</a>
+          <div class="nav-dropdown-menu">
+            <a href="future-events.html">Future Events</a>
+            <a href="past-events.html">Past Events</a>
+          </div>
+        </div>
         <a href="chess-literacy.html">Chess Literacy</a>
       </nav>
     </div>

--- a/script.js
+++ b/script.js
@@ -6,6 +6,10 @@ document.addEventListener('DOMContentLoaded', () => {
       link.classList.add('active');
     }
   });
+  const eventsToggle = document.querySelector('.nav-dropdown > a');
+  if (eventsToggle && (current === 'future-events.html' || current === 'past-events.html')) {
+    eventsToggle.classList.add('active');
+  }
 
   // Toggle navigation on small screens
   const toggleButton = document.getElementById('menu-toggle');

--- a/style.css
+++ b/style.css
@@ -92,6 +92,48 @@ nav a.active {
   background: rgba(16, 185, 129, 0.1);
 }
 
+.nav-dropdown {
+  position: relative;
+}
+
+.nav-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.4rem);
+  left: 0;
+  min-width: 200px;
+  background: #ffffff;
+  border: 1px solid rgba(16, 185, 129, 0.2);
+  border-radius: 10px;
+  padding: 0.5rem 0;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.08);
+  opacity: 0;
+  visibility: hidden;
+  transform: translateY(10px);
+  transition: opacity 0.2s ease, transform 0.2s ease, visibility 0.2s ease;
+  z-index: 1000;
+}
+
+.nav-dropdown:hover .nav-dropdown-menu,
+.nav-dropdown:focus-within .nav-dropdown-menu {
+  opacity: 1;
+  visibility: visible;
+  transform: translateY(0);
+}
+
+.nav-dropdown-menu a {
+  display: block;
+  padding: 0.6rem 1.2rem;
+  white-space: nowrap;
+}
+
+nav .nav-dropdown-menu a::after {
+  display: none;
+}
+
+nav .nav-dropdown-menu a:hover {
+  background: rgba(16, 185, 129, 0.1);
+}
+
 .menu-toggle {
   display: none;
   background: none;
@@ -428,6 +470,29 @@ footer a:hover {
     width: 100%;
     text-align: center;
     padding: 1rem;
+  }
+
+  .nav-dropdown {
+    width: 100%;
+  }
+
+  .nav-dropdown-menu {
+    position: static;
+    opacity: 1;
+    visibility: visible;
+    transform: none;
+    box-shadow: none;
+    border: none;
+    padding: 0;
+    display: none;
+  }
+
+  nav.show .nav-dropdown-menu {
+    display: block;
+  }
+
+  .nav-dropdown-menu a {
+    padding: 0.75rem 1rem;
   }
 
   .hero h1 {


### PR DESCRIPTION
### Motivation
- Consolidate the separate "Future Events" and "Past Events" links into a single navigation item called `Events` to simplify the header.
- Provide a hoverable dropdown that exposes `Future Events` and `Past Events` and also navigates to each page when clicked.
- Maintain usable behavior on mobile where the nav toggles open and dropdown items are accessible.
- Keep active-state highlighting for event pages so users see the `Events` tab as active when on either events page.

### Description
- Replaced separate links with a dropdown in header markup for `index.html`, `future-events.html`, `past-events.html`, and `chess-literacy.html` by adding a `.nav-dropdown` wrapper and `.nav-dropdown-menu` items.
- Added dropdown styling and transitions in `style.css` including desktop hover behavior and mobile adjustments so the dropdown expands when `nav.show` is present.
- Updated `script.js` to mark the `Events` toggle as active when the current page is `future-events.html` or `past-events.html`.
- Committed changes and updated the repo with the new navigation behavior.

### Testing
- Started a local static server with `python -m http.server` to serve the site, which launched successfully.
- Ran a Playwright script to hover the `Events` toggle and capture a screenshot, but the Playwright run timed out and failed to complete.
- No unit or integration test suites were executed for this static site change.
- Visual/manual verification is recommended after deployment to confirm hover and mobile behaviors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b042b4408331b0bbc7da9c9d7f92)