### PR TITLE
Add separate Home and About Me pages

### DIFF
--- a/about-me.html
+++ b/about-me.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>About Me | Emerald Knights</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <header>
+    <div class="header-content">
+      <div class="logo-section">
+        <img src="/images/emerald-knights-logo.png" alt="Emerald Knights Logo" class="logo">
+        <div class="site-title">Emerald Knights</div>
+      </div>
+      <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
+      <nav id="nav">
+        <a href="index.html">Home</a>
+        <a href="future-events.html">Future Events</a>
+        <a href="past-events.html">Past Events</a>
+        <a href="chess-literacy.html">Chess Literacy</a>
+        <a href="about-me.html" class="active">About Me</a>
+      </nav>
+    </div>
+  </header>
+
+  <section class="hero">
+    <div class="hero-content">
+      <h1>About Me</h1>
+      <p>Meet the founder behind Emerald Knights Chess Club.</p>
+    </div>
+  </section>
+
+  <main>
+    <section>
+      <h2 class="section-title">About the Founder</h2>
+      <div class="founder-section">
+        <img src="/images/IMG_0865.jpg" alt="Advay Bansal" class="founder-photo">
+        <div class="founder-info">
+          <h3>Advay Bansal</h3>
+          <p>
+            Advay Bansal is a FIDE Master with a peak Elo of 2393 and a former World Rank #4 in his international age category. With multiple victories at state and national tournaments, he has established himself as one of the strongest young players in the country. Advay's vision and competitive experience continue to drive our mission forward, inspiring players to challenge themselves and achieve success at every stage of their chess journey.
+          </p>
+          <div class="achievements">
+            <span class="achievement-badge">FIDE Master</span>
+            <span class="achievement-badge">Peak Elo: 2393</span>
+            <span class="achievement-badge">World Rank #4</span>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <footer>
+    &copy; 2025 Emerald Knights Chess Club | <a href="mailto:emeraldknightschess@gmail.com">Contact Us</a>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/chess-literacy.html
+++ b/chess-literacy.html
@@ -15,10 +15,11 @@
       </div>
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
-        <a href="index.html">About Us</a>
+        <a href="index.html">Home</a>
         <a href="future-events.html">Future Events</a>
         <a href="past-events.html">Past Events</a>
         <a href="chess-literacy.html" class="active">Chess Literacy</a>
+        <a href="about-me.html">About Me</a>
       </nav>
     </div>
   </header>

--- a/future-events.html
+++ b/future-events.html
@@ -15,10 +15,11 @@
       </div>
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
-        <a href="index.html">About Us</a>
+        <a href="index.html">Home</a>
         <a href="future-events.html" class="active">Future Events</a>
         <a href="past-events.html">Past Events</a>
         <a href="chess-literacy.html">Chess Literacy</a>
+        <a href="about-me.html">About Me</a>
       </nav>
     </div>
   </header>

--- a/index.html
+++ b/index.html
@@ -15,10 +15,11 @@
       </div>
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
-        <a href="index.html" class="active">About Us</a>
+        <a href="index.html" class="active">Home</a>
         <a href="future-events.html">Future Events</a>
         <a href="past-events.html">Past Events</a>
         <a href="chess-literacy.html">Chess Literacy</a>
+        <a href="about-me.html">About Me</a>
       </nav>
     </div>
   </header>
@@ -43,24 +44,6 @@
     </section>
 
     <section>
-      <h2 class="section-title">About the Founder</h2>
-      <div class="founder-section">
-        <img src="/images/IMG_0865.jpg" alt="Advay Bansal" class="founder-photo">
-        <div class="founder-info">
-          <h3>Advay Bansal</h3>
-          <p>
-            Advay Bansal is a FIDE Master with a peak Elo of 2393 and a former World Rank #4 in his international age category. With multiple victories at state and national tournaments, he has established himself as one of the strongest young players in the country. Advay's vision and competitive experience continue to drive our mission forward, inspiring players to challenge themselves and achieve success at every stage of their chess journey.
-          </p>
-          <div class="achievements">
-            <span class="achievement-badge">FIDE Master</span>
-            <span class="achievement-badge">Peak Elo: 2393</span>
-            <span class="achievement-badge">World Rank #4</span>
-          </div>
-        </div>
-      </div>
-    </section>
-
-    <section>
       <h2 class="section-title">Our Mission</h2>
       <div class="content-card">
         <p>
@@ -77,8 +60,3 @@
   <script src="script.js"></script>
 </body>
 </html>
-
-
-
-
-

--- a/past-events.html
+++ b/past-events.html
@@ -15,10 +15,11 @@
       </div>
       <button class="menu-toggle" id="menu-toggle" aria-label="Toggle navigation">☰</button>
       <nav id="nav">
-        <a href="index.html">About Us</a>
+        <a href="index.html">Home</a>
         <a href="future-events.html">Future Events</a>
         <a href="past-events.html" class="active">Past Events</a>
         <a href="chess-literacy.html">Chess Literacy</a>
+        <a href="about-me.html">About Me</a>
       </nav>
     </div>
   </header>


### PR DESCRIPTION
### Motivation
- Separate the founder biography from the site homepage so the Home page can focus on club overview and calls to action.
- Provide a dedicated `About Me` page for the founder to make the bio easier to link and maintain.
- Ensure site navigation lists the main landing page first and the personal bio last for clearer UX.

### Description
- Added `about-me.html` containing the founder bio and related markup.
- Removed the founder section from `index.html` so Home only contains club overview and mission content.
- Updated navigation across `index.html`, `future-events.html`, `past-events.html`, and `chess-literacy.html` to use `Home` as the first item and `About Me` as the last item, and adjusted `active` classes accordingly.
- Committed the changes to the repository.

### Testing
- Started a local server with `python -m http.server 8000`, which started successfully.
- Ran a Playwright script that loaded `http://127.0.0.1:8000/about-me.html` and captured a screenshot, which completed successfully and produced an artifact.
- Verified file updates with `git status` and inspected files with `nl` to confirm navbar and content changes.
- `git commit` completed successfully recording the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962b08945cc833182b5d4d9c68179ca)