### PR TITLE
Remove fall tournament listing from future events

### DIFF
--- a/future-events.html
+++ b/future-events.html
@@ -35,17 +35,6 @@
     <section>
       <h2 class="section-title">Future Events</h2>
       <ul>
-        <li>
-          <strong>Fall Open Tournament</strong>
-          <br>
-          <span style="color: #2d5a4d;">📅 August 2025</span>
-          <br>
-          <span style="color: #2d5a4d;">📍 Location: EHS Student Union</span>
-          <br>
-          <span style="color: #2d5a4d;">🕐 Time: 10:00 AM – 2:00 PM</span>
-          <br>
-          <a class="btn" href="mailto:contact@emerald-knights.org?subject=RSVP%20Summer%20Tournament">RSVP Now</a>
-        </li>
         <!-- Add more events here as needed -->
       </ul>
     </section>


### PR DESCRIPTION
### Motivation

- Remove the outdated Fall Open Tournament entry from `future-events.html` per site content update.
- Keep the Future Events list empty and ready for upcoming additions.
- Avoid displaying incorrect event details and RSVP link.

### Description

- Deleted the `<li>` block containing the "Fall Open Tournament" entry from `future-events.html` and left the placeholder comment inside the `<ul>`.
- No other HTML, CSS, or JS files were changed and layout/styling remain intact.
- Changes were staged and committed to the repository with `git commit`.

### Testing

- Served the site with `python -m http.server 8000` and rendered `future-events.html` using Playwright to capture a screenshot, which completed successfully.
- No unit or integration tests were run because this is a static content change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962d8f7950083318a2175cb4514f079)