### PR TITLE
Add 4th East Bay Open to past events

### DIFF
--- a/past-events.html
+++ b/past-events.html
@@ -50,6 +50,23 @@
             <img src="images/Tri-Valley_4.jpeg" alt="Tri-Valley Open Photo 4">
           </div>
         </li>
+
+        <li>
+          <strong>4th East Bay Open</strong>
+          <br>
+          <span style="color: #2d5a4d;">📅 October 11, 2025</span>
+          <br><br>
+          <p style="color: #2d5a4d; line-height: 1.6;">
+            We co-presented the 4th East Bay Open at Windemere Ranch Middle School in San Ramon on Saturday Oct. 11th. This collaborative tournament brought 210 players from across the Bay Area for an exciting day of chess.
+          </p>
+          <div class="event-photos">
+            <img src="images/october1.png" alt="4th East Bay Open Photo 1">
+            <img src="images/october2.png" alt="4th East Bay Open Photo 2">
+            <img src="images/october3.png" alt="4th East Bay Open Photo 3">
+            <img src="images/october4.png" alt="4th East Bay Open Photo 4">
+            <img src="images/october5.png" alt="4th East Bay Open Photo 5">
+          </div>
+        </li>
         
         <li>
           <strong>EHS Inaugural Chess Tournament (USCF Rated)</strong>

--- a/past-events.html
+++ b/past-events.html
@@ -36,22 +36,6 @@
       <h2 class="section-title">Past Events</h2>
       <ul>
         <li>
-          <strong>Tri-Valley Open</strong>
-          <br>
-          <span style="color: #2d5a4d;">📅 September 20, 2025</span>
-          <br><br>
-          <p style="color: #2d5a4d; line-height: 1.6;">
-            We co-presented the Tri-Valley Open with the Emerald Hills Chess Club and Tri-Valley Chess League. This collaborative tournament with 149 participants brought together players from across the region for an exciting day of competitive chess.
-          </p>
-          <div class="event-photos">
-            <img src="images/Tri-Valley_1.jpeg" alt="Tri-Valley Open Photo 1">
-            <img src="images/Tri-Valley_2.jpeg" alt="Tri-Valley Open Photo 2">
-            <img src="images/Tri-Valley_3.jpeg" alt="Tri-Valley Open Photo 3">
-            <img src="images/Tri-Valley_4.jpeg" alt="Tri-Valley Open Photo 4">
-          </div>
-        </li>
-
-        <li>
           <strong>4th East Bay Open</strong>
           <br>
           <span style="color: #2d5a4d;">📅 October 11, 2025</span>
@@ -65,6 +49,22 @@
             <img src="images/october3.png" alt="4th East Bay Open Photo 3">
             <img src="images/october4.png" alt="4th East Bay Open Photo 4">
             <img src="images/october5.png" alt="4th East Bay Open Photo 5">
+          </div>
+        </li>
+
+        <li>
+          <strong>Tri-Valley Open</strong>
+          <br>
+          <span style="color: #2d5a4d;">📅 September 20, 2025</span>
+          <br><br>
+          <p style="color: #2d5a4d; line-height: 1.6;">
+            We co-presented the Tri-Valley Open with the Emerald Hills Chess Club and Tri-Valley Chess League. This collaborative tournament with 149 participants brought together players from across the region for an exciting day of competitive chess.
+          </p>
+          <div class="event-photos">
+            <img src="images/Tri-Valley_1.jpeg" alt="Tri-Valley Open Photo 1">
+            <img src="images/Tri-Valley_2.jpeg" alt="Tri-Valley Open Photo 2">
+            <img src="images/Tri-Valley_3.jpeg" alt="Tri-Valley Open Photo 3">
+            <img src="images/Tri-Valley_4.jpeg" alt="Tri-Valley Open Photo 4">
           </div>
         </li>
         


### PR DESCRIPTION
### Motivation
- Add a new past event entry for the 4th East Bay Open so the site records the tournament and displays its photos in the same layout as existing entries.
- Keep visual consistency by following the exact markup and `event-photos` layout used by other past events.

### Description
- Updated `past-events.html` to insert a new `<li>` for the "4th East Bay Open" dated `📅 October 11, 2025` with the provided description.
- Added five images in the same side-by-side `div.event-photos` format using `images/october1.png` through `images/october5.png` in the requested order.
- Preserved existing HTML structure and styling to match the other past event entries.

### Testing
- Started a local HTTP server with `python -m http.server` to serve the site and verified the page loaded successfully. (succeeded)
- Captured a full-page screenshot using a Playwright script to confirm the new event and images render as expected. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962dc00ec348331b149220210dacd41)