### PR TITLE
Add library workshop image to Future Events and update Chess Literacy recap

### DIFF
--- a/chess-literacy.html
+++ b/chess-literacy.html
@@ -40,25 +40,22 @@
           <span style="color: #2d5a4d; font-size: 1.1rem;">🕐 2:00 PM – 3:30 PM</span><br>
           <span style="color: #2d5a4d; font-size: 1.1rem;">📍 Dublin Library - Virginia Bennett Room</span>
         </p>
-        
-        <div style="text-align: center; margin: 2rem 0;">
-          <img src="images/library_workshop.jpg" alt="Library Workshop" style="max-width: 500px; width: 100%; border-radius: 12px; box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);">
-        </div>
 
         <p style="margin-bottom: 1.5rem; font-size: 1.1rem; line-height: 1.8; color: #2d5a4d;">
-          Emerald Knights Chess Club is a program where players of all ages and skill levels can explore the game of chess. Through engaging lessons, friendly matches, and tournaments, participants build strategic thinking, problem-solving skills, and confidence in a welcoming environment.
+          Thank you to everyone who joined us for a wonderful afternoon of chess learning and community fun. The workshop wrapped up with new friendships, stronger strategic skills, and plenty of smiles around the boards.
         </p>
 
         <div style="background: #f8fdf9; border: 1px solid rgba(16, 185, 129, 0.2); border-radius: 12px; padding: 1.5rem; margin-bottom: 2rem;">
           <p style="color: #2d5a4d; font-size: 1rem; line-height: 1.7;">
-            <strong style="color: #10b981;">Note:</strong> This program is geared towards elementary school and middle school aged children, but anyone is welcome as there is space.
+            <strong style="color: #10b981;">Workshop recap:</strong> Players of all ages explored key concepts, practiced friendly matches, and built confidence in a welcoming environment.
           </p>
         </div>
 
-        <div style="text-align: center;">
-          <a href="https://aclibrary.bibliocommons.com/events/68c8c3fa09c63c2f007fddda" target="_blank" class="cta-button" style="display: inline-block;">
-            📚 Register at Library Website
-          </a>
+        <div style="display: grid; gap: 1.5rem; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); margin: 2rem 0;">
+          <img src="images/library1.jpeg" alt="Chess literacy workshop participants playing games" style="width: 100%; border-radius: 12px; box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);">
+          <img src="images/library2.jpeg" alt="Coach guiding students during the chess literacy workshop" style="width: 100%; border-radius: 12px; box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);">
+          <img src="images/library3.jpeg" alt="Group of attendees learning chess strategies at the library" style="width: 100%; border-radius: 12px; box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);">
+          <img src="images/library4.jpeg" alt="Participants smiling after the chess literacy workshop" style="width: 100%; border-radius: 12px; box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);">
         </div>
       </div>
     </section>

--- a/future-events.html
+++ b/future-events.html
@@ -35,6 +35,22 @@
     <section>
       <h2 class="section-title">Future Events</h2>
       <ul>
+        <li style="list-style: none; margin-bottom: 2rem;">
+          <div class="content-card">
+            <h3 style="margin-bottom: 1rem; color: #2d5a4d;">Emerald Knights Chess Literacy Workshop</h3>
+            <p style="margin-bottom: 1rem;">
+              <span style="color: #2d5a4d; font-size: 1.1rem;">📅 Saturday, February 22</span><br>
+              <span style="color: #2d5a4d; font-size: 1.1rem;">🕐 2:30 PM – 4:00 PM</span><br>
+              <span style="color: #2d5a4d; font-size: 1.1rem;">📍 Dublin Library - Virginia Bennett Room</span>
+            </p>
+            <div style="text-align: center; margin: 2rem 0;">
+              <img src="images/library_workshop.jpg" alt="Library Workshop" style="max-width: 500px; width: 100%; border-radius: 12px; box-shadow: 0 4px 20px rgba(16, 185, 129, 0.2);">
+            </div>
+            <p style="margin-bottom: 0; font-size: 1.05rem; line-height: 1.7; color: #2d5a4d;">
+              Join us for a welcoming chess literacy workshop with engaging lessons, friendly matches, and plenty of strategy tips for players of all ages.
+            </p>
+          </div>
+        </li>
         <!-- Add more events here as needed -->
       </ul>
     </section>


### PR DESCRIPTION
### Motivation
- Reflect that the library chess literacy workshop has concluded and provide a short recap with photos.
- Surface the upcoming workshop date/time on the Future Events page so visitors can plan to attend.
- Restore the same workshop image used on the workshop page into the Future Events listing so layouts match.

### Description
- Updated `chess-literacy.html` to replace the registration CTA with post-event recap copy and added a four-photo gallery using `images/library1.jpeg` through `images/library4.jpeg`.
- Added a new entry for the Emerald Knights Chess Literacy Workshop (Saturday, February 22, 2:30 PM – 4:00 PM) to `future-events.html` and inserted `images/library_workshop.jpg` with matching styling.
- Adjusted copy and card styling to reflect the concluded event and maintain consistent image presentation across pages.

### Testing
- Served the site locally with `python -m http.server 8000` and the server started successfully.
- Ran a Playwright script that opened `http://127.0.0.1:8000/chess-literacy.html` and saved a screenshot as `artifacts/chess-literacy-updated.png` to validate the updated page rendering.
- No automated unit tests were run because these are static HTML content changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69630557fe288331a71a35ebe703b606)